### PR TITLE
reduced debug logging in production

### DIFF
--- a/remoteaccess.env.example
+++ b/remoteaccess.env.example
@@ -1,21 +1,30 @@
-# application mode
+# application mode # production or development
 APP_ENV='production'
- 
 
 # ======================
 # emoncms api read key
 # ======================
-EMONCMS_APIKEY=''
+EMONCMS_APIKEY='READ ONLY API KEY'
 #
 # =====================
 # ensure the read api key is used. no writing to system allowed for read api key
 
-# mqtt broker connection
+# MQTT BROKER CONNECTION SETTINGS:
+# =====================
+# use quoted strings
 MQTT_HOST='mqtt.emoncms.org'
+# use quoted strings
 MQTT_USERNAME=''
+# use quoted strings
 MQTT_PASSWORD=''
+# use unquoted integer
 MQTT_PORT=8883
+# use true or false (lowercase unquoted strings)
 MQTT_TLS=true
+# use: tcp or websockets quoted strings
+MQTT_TRANSPORT='tcp'
 
-# Save As .env for production
-# Save As .env.dev for development
+# =====================
+
+# Save As remoteaccess.env for production
+# Save As remoteaccess.env.dev for development


### PR DESCRIPTION
fix issue #10 
`remoteaccess.env` now has `APP_ENV` variable to enable detailed logging

### Successfull connections
when set to `'production'` the `journalctl` log will only see 1 line when the service starts and 3 lines per connection :
```
[timestamp] [host] systemd[pid]: Started Emoncms RemoteAccess script.
[timestamp] [host] remoteaccess[pid]: Starting EmonCMS RemoteAccess
[timestamp] [host] remoteaccess[pid]: Connected to broker: localhost
[timestamp] [host] remoteaccess[pid]: Subscribed and responding to messages
```

### Errors
If python script exits due to connection issues, authentication or scripting errors the script is restarted by the systemd daemon should restart after 60 s.

if `APP_ENV` is set to `"production"` while the script exists `journalctl` should output something similar to:
```
[timestamp] [host] systemd[pid]: remoteaccess.service: Service hold-off time over, scheduling restart.
[timestamp] [host] systemd[pid]: remoteaccess.service: Scheduled restart job, restart counter is at 2.
[timestamp] [host] systemd[pid]: Stopped Emoncms RemoteAccess script.
[timestamp] [host] systemd[pid]: Started Emoncms RemoteAccess script.
[timestamp] [host] remoteaccess[pid]: Starting EmonCMS RemoteAccess
[timestamp] [host] remoteaccess[pid]: Error: 111. Connection refused
[timestamp] [host] remoteaccess[pid]: Exit. RemoteAccess service will retry script in 60s
```

### Detailed logging
temporarily set `APP_ENV` to `"development"` to see more detailed logging
(16 lines per connection and 7 lines per message)
